### PR TITLE
Bump uuid to ^11.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "react-icons": "^4.11.0",
                 "react-select": "^5.8.0",
                 "react-tooltip": "^5.25.0",
-                "uuid": "^9.0.0"
+                "uuid": "^11.1.1"
             },
             "devDependencies": {
                 "@babel/plugin-transform-react-jsx": "^7.25.9",
@@ -9496,16 +9496,16 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/vali-date": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "react-icons": "^4.11.0",
         "react-select": "^5.8.0",
         "react-tooltip": "^5.25.0",
-        "uuid": "^9.0.0"
+        "uuid": "^11.1.1"
     },
     "peerDependencies": {
         "@inertiajs/react": "^2.0.0",


### PR DESCRIPTION
Clears GHSA-w5hq-g745-h8pq (missing buffer bounds check in v3/v5/v6 generation when a buf is passed). We only use plain v4() in toast.tsx so we were never exposed in practice, but every app consuming the SDK inherits the audit flag, the portal's npm audit has been pointing at us.

uuid ^9.0.0 → ^11.1.1. Went to the patched 11.x line rather than the latest 14 major to keep the change minimal, v4 import is unchanged.

54 tests pass, build clean.

Once this is released, consuming apps just need a regular npm update @star-insure/sdk to clear the finding.