### PR TITLE
Add dom.iterable to tsconfig lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         "target": "ESNext",
         "lib": [
             "dom",
+            "dom.iterable",
             "esnext"
         ],
         "types": ["vitest/globals"],


### PR DESCRIPTION
npm run release was failing with TS2339, URLSearchParams.entries() does not exist. entries() is typed in dom.iterable which was missing from the lib array, the code had always relied on that gap going unchecked and the dep bumps moved api-extractor's bundled TypeScript to 5.9.3 which catches it.

One line, build and 54 tests pass.